### PR TITLE
Slice off the matching path length, rather than splitting

### DIFF
--- a/src/getPathMatch.ts
+++ b/src/getPathMatch.ts
@@ -14,7 +14,7 @@ export function getPathMatch(pathName: string, parsedPath: ParsedPath) {
         return false;
       }
 
-      pathName = pathName.split(pathPart)[1];
+      pathName = pathName.slice(pathPart.length);
     } else {
       const [first, ...rest] = pathName.split("/");
 

--- a/src/tests/defineRoute.spec.ts
+++ b/src/tests/defineRoute.spec.ts
@@ -104,6 +104,21 @@ describe("defineRoute.getMatch", () => {
     });
   });
 
+  it("should match for parameterized route at beginning", () => {
+    const routeDefinition = getRouteDefinition(
+      { userId: "path.param.string" },
+      p => `/${p.userId}/hi`
+    );
+
+    const match = routeDefinition.match({
+      pathName: "/abc/hi"
+    });
+
+    expect(match).toEqual({
+      userId: "abc"
+    });
+  });
+
   it("should match for parameterized route not at end", () => {
     const routeDefinition = getRouteDefinition(
       { userId: "path.param.string" },


### PR DESCRIPTION
The call to `pathName.split(pathPart)[1]` has unintended consequences when the current pathPart of a route is simply "/", rather than selecting the tail end of the entire path it will split up the path and select just the part with index `1`. This happens when matching a route like `/${p.test}/test`.

Since there's already a check that `pathName.startsWith(pathPart)`, we should be fine to simply call `pathName.slice(pathPart.length)` and slice off the start of the path.