### PR TITLE
Fix JSX syntax on docs/guides/page-layout

### DIFF
--- a/docs/guides/page-layout.md
+++ b/docs/guides/page-layout.md
@@ -55,33 +55,33 @@ function Footer() {
 
 function HomePage() {
   return <>
-    <Header>
+    <Header />
     <div>Home Page</div>
-    </Footer>
+    <Footer />
   </>
 }
 
 function FooPage() {
   return <>
-    <Header>
+    <Header />
     <div>Foo Page</div>
-    </Footer>
+    <Footer />
   </>
 }
 
 function BarPage() {
   return <>
-    <Header>
+    <Header />
     <div>Bar Page</div>
-    </Footer>
+    <Footer />
   </>
 }
 
 function NotFoundPage() {
   return <>
-    <Header>
+    <Header />
     <div>Bar Page</div>
-    </Footer>
+    <Footer />
   </>
 }
 ```
@@ -121,9 +121,9 @@ function App() {
   }
 
   return <>
-    <Header>
+    <Header />
     {page}
-    </Footer>
+    <Footer />
   </>;
 }
 


### PR DESCRIPTION
Example code on that guide have no corresponding closing tag and is invalid as JSX.

This PR changes them that have no children components to self-closing tag.